### PR TITLE
Handling for the scenario where `blastn -query` returns no results

### DIFF
--- a/prep_genome_lib/ctat-vif-lib-integration.py
+++ b/prep_genome_lib/ctat-vif-lib-integration.py
@@ -75,18 +75,18 @@ def main():
 
     ## generate masked genome.
     # make regions file
-    logger.info("masking virus-homologous regions from the genome")
-    df = pd.read_csv(blastn_outfile, sep="\t", header=None, usecols=[1,2,8,9])
-    df.columns = ["chrom", "perid", "end5", "end3"]
+    if sum(1 for l in open(blastn_outfile))>0:
+        df = pd.read_csv(blastn_outfile, sep="\t", header=None, usecols=[1,2,8,9])
+        df.columns = ["chrom", "perid", "end5", "end3"]
+        df = df[ df['perid'] >= 90 ]  # filter, require min 90% identity
+        df['lend'] = df.apply(lambda x: min(x['end5'], x['end3']), axis=1)
+        df['rend'] = df.apply(lambda x: max(x['end5'], x['end3']), axis=1)
+        df['lend'] = df['lend']-1 
+        df = df[ ['chrom', 'lend', 'rend'] ]
 
-    # filter, require min 90% identity
-    df = df[ df['perid'] >= 90 ] 
-    
-    df['lend'] = df.apply(lambda x: min(x['end5'], x['end3']), axis=1)
-    df['rend'] = df.apply(lambda x: max(x['end5'], x['end3']), axis=1)
-
-    df['lend'] = df['lend']-1
-    df = df[ ['chrom', 'lend', 'rend'] ]
+    else: 
+        df = pd.DataFrame(columns=['chrom', 'lend', 'rend'])
+        
     bed_filename = blastn_outfile + ".bed"
     df.to_csv(bed_filename, sep="\t", header=False, index=False)
     


### PR DESCRIPTION
Hi there,

Yesterday I ran into a situation where `prep_genome_lib/ctat-vif-lib-integration.py` errored on line 79:
`    df = pd.read_csv(blastn_outfile, sep="\t", header=None, usecols=[1,2,8,9])` when the previous blastn step outputs a file with no contents. 

This checks for the number of lines in the blastn output file and bypasses the processing instead creating a dummy file just with column headers for use downstream. 

I am a bit of a python novice so please let me know I've done something silly!
